### PR TITLE
Dropbox auth host

### DIFF
--- a/lib/dropbox.rb
+++ b/lib/dropbox.rb
@@ -28,9 +28,9 @@ module Dropbox
   # The API version this client works with.
   VERSION = "0"
   # The host serving API requests.
-  HOST = "http://api.dropbox.com"
+  HOST = "http://www.dropbox.com"
   # The SSL host serving API requests.
-  SSL_HOST = "https://api.dropbox.com"
+  SSL_HOST = "https://www.dropbox.com"
   # Alternate hosts for other API requests.
   ALTERNATE_HOSTS = {
     'event_content' => 'http://api-content.dropbox.com',

--- a/lib/dropbox.rb
+++ b/lib/dropbox.rb
@@ -27,10 +27,14 @@ require 'dropbox/session'
 module Dropbox
   # The API version this client works with.
   VERSION = "0"
+  # The host to authenticate user.
+  AUTH_HOST = "http://www.dropbox.com"
+  # The SSL host to authenticate user.
+  AUTH_SSL_HOST = "https://www.dropbox.com"
   # The host serving API requests.
-  HOST = "http://www.dropbox.com"
+  HOST = "http://api.dropbox.com"
   # The SSL host serving API requests.
-  SSL_HOST = "https://www.dropbox.com"
+  SSL_HOST = "https://api.dropbox.com"
   # Alternate hosts for other API requests.
   ALTERNATE_HOSTS = {
     'event_content' => 'http://api-content.dropbox.com',

--- a/lib/dropbox/session.rb
+++ b/lib/dropbox/session.rb
@@ -76,7 +76,7 @@ module Dropbox
       @proxy = options[:proxy] || ENV["HTTP_PROXY"] || ENV["http_proxy"]
       @proxy = nil if options[:noproxy].to_bool
       @consumer = OAuth::Consumer.new(oauth_key, oauth_secret,
-                                      :site => (@ssl ? Dropbox::SSL_HOST : Dropbox::HOST),
+                                      :site => (@ssl ? Dropbox::AUTH_SSL_HOST : Dropbox::AUTH_HOST),
                                       :proxy => @proxy,
                                       :request_token_path => "/#{Dropbox::VERSION}/oauth/request_token",
                                       :authorize_path => "/#{Dropbox::VERSION}/oauth/authorize",

--- a/spec/dropbox/session_spec.rb
+++ b/spec/dropbox/session_spec.rb
@@ -6,7 +6,7 @@ describe Dropbox::Session do
       key = 'test_key'
       secret = 'test_secret'
       options_hash = [ 'request_token', 'authorize', 'access_token' ].inject({}) { |hsh, cur| hsh["#{cur}_path".to_sym] = "/#{Dropbox::VERSION}/oauth/#{cur}" ; hsh }
-      options_hash[:site] = Dropbox::HOST
+      options_hash[:site] = Dropbox::AUTH_HOST
       options_hash[:proxy] = nil
 
       consumer_mock = mock('OAuth::Consumer')
@@ -20,7 +20,7 @@ describe Dropbox::Session do
       key = 'test_key'
       secret = 'test_secret'
       options_hash = [ 'request_token', 'authorize', 'access_token' ].inject({}) { |hsh, cur| hsh["#{cur}_path".to_sym] = "/#{Dropbox::VERSION}/oauth/#{cur}" ; hsh }
-      options_hash[:site] = Dropbox::SSL_HOST
+      options_hash[:site] = Dropbox::AUTH_SSL_HOST
       options_hash[:proxy] = nil
 
       consumer_mock = mock('OAuth::Consumer')
@@ -34,7 +34,7 @@ describe Dropbox::Session do
       key = 'test_key'
       secret = 'test_secret'
       options_hash = [ 'request_token', 'authorize', 'access_token' ].inject({}) { |hsh, cur| hsh["#{cur}_path".to_sym] = "/#{Dropbox::VERSION}/oauth/#{cur}" ; hsh }
-      options_hash[:site] = Dropbox::HOST
+      options_hash[:site] = Dropbox::AUTH_HOST
       options_hash[:proxy] = proxy = mock('proxy')
 
       consumer_mock = mock('OAuth::Consumer')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'bundler'
 Bundler.require :default, :test
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))


### PR DESCRIPTION
Seems like the api.dropbox.com doesn't work for authentcation any more:
http://forums.dropbox.com/topic.php?id=27883&replies=3

Changed the auth host to www.dropbox.com
