### PR TITLE
Extraneous HTTP Request

### DIFF
--- a/lib/dropbox/session.rb
+++ b/lib/dropbox/session.rb
@@ -81,7 +81,7 @@ module Dropbox
                                       :request_token_path => "/#{Dropbox::VERSION}/oauth/request_token",
                                       :authorize_path => "/#{Dropbox::VERSION}/oauth/authorize",
                                       :access_token_path => "/#{Dropbox::VERSION}/oauth/access_token")
-      @request_token = @consumer.get_request_token
+      @request_token = @consumer.get_request_token unless options[:already_authorized] == true
     end
 
     # Returns a URL that is used to complete the authorization process. Visiting
@@ -169,7 +169,7 @@ module Dropbox
       consumer_key, consumer_secret, authorized, token, token_secret, ssl = YAML.load(StringIO.new(data))
       raise ArgumentError, "Must provide a properly serialized #{self.to_s} instance" unless [ consumer_key, consumer_secret, token, token_secret ].all? and authorized == true or authorized == false
 
-      session = self.new(consumer_key, consumer_secret, :ssl => ssl)
+      session = self.new(consumer_key, consumer_secret, :ssl => ssl, :already_authorized => authorized)
       if authorized then
         session.instance_variable_set :@access_token, OAuth::AccessToken.new(session.instance_variable_get(:@consumer), token, token_secret)
       else

--- a/spec/dropbox/session_spec.rb
+++ b/spec/dropbox/session_spec.rb
@@ -156,14 +156,14 @@ describe Dropbox::Session do
     end
 
     it "should return a properly initialized unauthorized instance" do
-      Dropbox::Session.should_receive(:new).once.with('key', 'secret', :ssl => true).and_return(@mock_session)
+      Dropbox::Session.should_receive(:new).once.with('key', 'secret', :ssl => true, :already_authorized => false).and_return(@mock_session)
 
       Dropbox::Session.deserialize([ 'key', 'secret', false, 'a', 'b', true ].to_yaml).should eql(@mock_session)
       #TODO request token remains opaque for purposes of testing
     end
 
     it "should allow the SSL option to be left out" do
-      Dropbox::Session.should_receive(:new).once.with('key', 'secret', :ssl => nil).and_return(@mock_session)
+      Dropbox::Session.should_receive(:new).once.with('key', 'secret', :ssl => nil, :already_authorized=>false).and_return(@mock_session)
 
       Dropbox::Session.deserialize([ 'key', 'secret', false, 'a', 'b' ].to_yaml).should eql(@mock_session)
     end


### PR DESCRIPTION
Hi,

I just fixed what I believe is a bug: an extra HTTP request was made in `Dropbox::Session.deserialize`, to get an Oauth request token even if the session is already authorized.

Cheers,
Mathieu
