### PR TITLE
Fixed bug preventing getting a list of documents from your dropbox root

### DIFF
--- a/lib/dropbox.rb
+++ b/lib/dropbox.rb
@@ -60,7 +60,7 @@ module Dropbox
 
   def self.check_path(path) # :nodoc:
     raise ArgumentError, "Backslashes are not allowed in Dropbox paths" if path.include?('\\')
-    raise ArgumentError, "File names are limited to 255 characters" if path.split('/').last.size > 255
+    raise ArgumentError, "File names are limited to 255 characters" if path.split('/').last.size > 255 unless path.empty?
     return path
   end
 end

--- a/spec/dropbox_spec.rb
+++ b/spec/dropbox_spec.rb
@@ -53,5 +53,10 @@ describe Dropbox do
       path = "valid path/here"
       lambda { Dropbox.check_path(path).should eql(path) }.should_not raise_error
     end
+
+    it "should allow a path that is empty" do
+      path = {}
+      lambda { Dropbox.check_path(path).should eql(path) }.should_not raise_error
+    end
   end
 end


### PR DESCRIPTION
Bug was added when checking for file length in check_path.
