### PR TITLE
Illustrating serializing the session

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -26,6 +26,16 @@ http://developers.dropbox.com
  uploaded_file.move 'new_name.txt'
  uploaded_file.delete
 
+ # STEP 3: Save session for later
+ File.open('serialized_session.txt', 'w') do |f|
+   f.puts session.serialize
+ end
+
+ # STEP 4: Play with saved session!
+ new_session = Dropbox::Session.deserialize(File.read('serialized_session.txt'))
+ account = new_session.account
+ puts account.display_name
+
 == Tutorial by Example, Rails Edition
 
 A simple Rails controller that allows a user to first authorize their Dropbox


### PR DESCRIPTION
I opened an issue because I didn't understand how to stay authorized and was pointed at #serialize as the solution. I feel like this could be clearer in the README, so I added to the basic example to illustrate how serializing the session works. I figured if I was confused maybe someone else could be and this might help.

Thanks for the great gem!! :)
Jon
